### PR TITLE
Fix for tvOS native audio menu language selector

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -1134,12 +1134,20 @@ static int const RCTVideoUnset = -1;
       }
     }
   } else { // default. invalid type or "system"
-    [_player.currentItem selectMediaOptionAutomaticallyInMediaSelectionGroup:group];
-    return;
+    #if TARGET_OS_TV
+    // Do noting. Fix for tvOS native audio menu language selector
+    #else
+      [_player.currentItem selectMediaOptionAutomaticallyInMediaSelectionGroup:group];
+      return;
+    #endif
   }
-  
-  // If a match isn't found, option will be nil and text tracks will be disabled
-  [_player.currentItem selectMediaOption:mediaOption inMediaSelectionGroup:group];
+
+    #if TARGET_OS_TV
+    // Do noting. Fix for tvOS native audio menu language selector
+    #else
+       // If a match isn't found, option will be nil and text tracks will be disabled
+       [_player.currentItem selectMediaOption:mediaOption inMediaSelectionGroup:group];
+    #endif
 }
 
 - (void)setSelectedAudioTrack:(NSDictionary *)selectedAudioTrack {


### PR DESCRIPTION
This fixes the tvOS language menu issue that I have described here: 
https://github.com/react-native-video/react-native-video/issues/2457