### PR TITLE
Fix constant definition for Windows resize modes

### DIFF
--- a/windows/ReactNativeVideoCPP/ReactVideoViewManager.cpp
+++ b/windows/ReactNativeVideoCPP/ReactVideoViewManager.cpp
@@ -30,9 +30,9 @@ void ReactVideoViewManager::ReactContext(IReactContext reactContext) noexcept {
 winrt::Microsoft::ReactNative::ConstantProviderDelegate ReactVideoViewManager::ExportedViewConstants() noexcept {
   return [](winrt::Microsoft::ReactNative::IJSValueWriter const &constantWriter) {
     WriteProperty(constantWriter, L"ScaleNone", to_hstring(std::to_string((int)Stretch::None)));
-    WriteProperty(constantWriter, L"ScaleToFill", to_hstring(std::to_string((int)Stretch::UniformToFill)));
+    WriteProperty(constantWriter, L"ScaleToFill", to_hstring(std::to_string((int)Stretch::Fill)));
     WriteProperty(constantWriter, L"ScaleAspectFit", to_hstring(std::to_string((int)Stretch::Uniform)));
-    WriteProperty(constantWriter, L"ScaleAspectFill", to_hstring(std::to_string((int)Stretch::Fill)));
+    WriteProperty(constantWriter, L"ScaleAspectFill", to_hstring(std::to_string((int)Stretch::UniformToFill)));
   };
 }
 


### PR DESCRIPTION
In the Windows implementation, the constant definitions for 2 resize modes were swapped...leading to issues. The JS resizeMode of "stretch" was using a Windows equivalent for aspectFill, and vice versa.

-Stretch (Windows Stretch::Fill) and aspectFill (Windows Stretch::uniformFill) were switched!

