### PR TITLE
Adding Dolby Atmos workaround for iOS 15.x

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -5,6 +5,7 @@
 #import <React/UIView+React.h>
 #include <MediaAccessibility/MediaAccessibility.h>
 #include <AVFoundation/AVFoundation.h>
+#import <MediaPlayer/MediaPlayer.h>
 
 static NSString *const statusKeyPath = @"status";
 static NSString *const playbackLikelyToKeepUpKeyPath = @"playbackLikelyToKeepUp";
@@ -39,6 +40,9 @@ static int const RCTVideoUnset = -1;
   /* DRM */
   NSDictionary *_drm;
   AVAssetResourceLoadingRequest *_loadingRequest;
+  
+  /* Workaround for Dolby Atmos on OS 15.2 and beyond */
+  id _remoteCommandHandlerForSpatialAudio;
   
   /* Required to publish events */
   RCTEventDispatcher *_eventDispatcher;
@@ -217,8 +221,33 @@ static int const RCTVideoUnset = -1;
   [[NSNotificationCenter defaultCenter] removeObserver:self];
   [self removePlayerLayer];
   [self removePlayerItemObservers];
+  [self removeSpatialAudioRemoteCommandHandler];
   [_player removeObserver:self forKeyPath:playbackRate context:nil];
   [_player removeObserver:self forKeyPath:externalPlaybackActive context: nil];
+}
+
+#pragma mark - Spatial Audio / Dolby Atmos Workaround
+
+/* These functions are a temporarily workaround to enable the rendering of Dolby Atmos on
+ * iOS 15 and above.
+ */
+- (void)addSpatialAudioRemoteCommandHandler
+{
+  MPRemoteCommand *remoteCommand = [MPRemoteCommandCenter sharedCommandCenter].playCommand;
+  
+  _remoteCommandHandlerForSpatialAudio = [remoteCommand addTargetWithHandler:^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent *event) {
+      return MPRemoteCommandHandlerStatusSuccess;
+  }];
+}
+
+- (void)removeSpatialAudioRemoteCommandHandler
+{
+  MPRemoteCommand *remoteCommand = [MPRemoteCommandCenter sharedCommandCenter].playCommand;
+  
+  if (_remoteCommandHandlerForSpatialAudio != nil) {
+      [remoteCommand removeTarget:_remoteCommandHandlerForSpatialAudio];
+      _remoteCommandHandlerForSpatialAudio = nil;
+  }
 }
 
 #pragma mark - App lifecycle handlers
@@ -930,9 +959,11 @@ static int const RCTVideoUnset = -1;
   if (paused) {
     [_player pause];
     [_player setRate:0.0];
+    [self removeSpatialAudioRemoteCommandHandler];
   } else {
 
     [self configureAudio];
+    [self addSpatialAudioRemoteCommandHandler];
 
     if (@available(iOS 10.0, *) && !_automaticallyWaitsToMinimizeStalling) {
       [_player playImmediatelyAtRate:_rate];


### PR DESCRIPTION
Dolby Atmos does not play on iPhones starting with iOS 15.0 and beyond (including on AirPods, or via built-in headphones, where supported). Atmos does play on iPads

This PR includes a workaround based on previous investigation that allows Atmos to play on iOS 15.x. To test if Atmos is playing correctly, use the test stream found at : https://ott.dolby.com/OnDelKits/DDP/Dolby_Digital_Plus_Online_Delivery_Kit_v1.5/Test_Signals/muxed_streams/HLS/Manifest_fMP4/Audio_ID_720p_50fps_h264_special_6ch_640kbps_ddp_joc.m3u8

This stream will play static that alternates position if Atmos is playing. If Atmos is not playing, the audio will play in mono.

- Add and remove spatial audio remote command handler
- Whenever we play video, we must add this event handler that returns a success status for all remote command events
- We add the handler whenever the video is playing and remove it whenever the video stops playing (or is destroyed)
- This is a workaround to get Dolby Atmos working on iOS 15 and above, until the issue is fixed by Apple


