### PR TITLE
It seems, that if we have several Video elements and if we remove han…

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -389,6 +389,8 @@ static int const RCTVideoUnset = -1;
   [self removePlayerLayer];
   [self removePlayerTimeObserver];
   [self removePlayerItemObservers];
+  [self removeSpatialAudioRemoteCommandHandler];
+
   dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t) 0), dispatch_get_main_queue(), ^{
     
     // perform on next run loop, otherwise other passed react-props may not be set
@@ -397,6 +399,8 @@ static int const RCTVideoUnset = -1;
       _playerItem = playerItem;
       [self setPreferredForwardBufferDuration:_preferredForwardBufferDuration];
       [self addPlayerItemObservers];
+      [self addSpatialAudioRemoteCommandHandler];
+
       [self setFilter:self->_filterName];
       [self setMaxBitRate:self->_maxBitRate];
       
@@ -959,11 +963,9 @@ static int const RCTVideoUnset = -1;
   if (paused) {
     [_player pause];
     [_player setRate:0.0];
-    [self removeSpatialAudioRemoteCommandHandler];
   } else {
 
     [self configureAudio];
-    [self addSpatialAudioRemoteCommandHandler];
 
     if (@available(iOS 10.0, *) && !_automaticallyWaitsToMinimizeStalling) {
       [_player playImmediatelyAtRate:_rate];


### PR DESCRIPTION
Dolby Atmos does not play on iPhones starting with iOS 15.0 and beyond (including on AirPods, or via built-in headphones, where supported). Atmos does play on iPads

This PR includes a workaround based on previous investigation that allows Atmos to play on iOS 15.x. To test if Atmos is playing correctly, use the test stream found at : https://ott.dolby.com/OnDelKits/DDP/Dolby_Digital_Plus_Online_Delivery_Kit_v1.5/Test_Signals/muxed_streams/HLS/Manifest_fMP4/Audio_ID_720p_50fps_h264_special_6ch_640kbps_ddp_joc.m3u8

This stream will play static that alternates position if Atmos is playing. If Atmos is not playing, the audio will play in mono.

Add and remove spatial audio remote command handler
Whenever we setSrc video, we must add this event handler that returns a success status for all remote command events
We add the handler whenever the video is applied to Video element and remove it when Video element is deallocated.
This is a workaround to get Dolby Atmos working on iOS 15 and above, until the issue is fixed by Apple