### PR TITLE
Bugfix/XHUB-4228: Revert iOS 15 MPRemoteCommandCenter workaround

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -40,10 +40,7 @@ static int const RCTVideoUnset = -1;
   /* DRM */
   NSDictionary *_drm;
   AVAssetResourceLoadingRequest *_loadingRequest;
-  
-  /* Workaround for Dolby Atmos on OS 15.2 and beyond */
-  id _remoteCommandHandlerForSpatialAudio;
-  
+   
   /* Required to publish events */
   RCTEventDispatcher *_eventDispatcher;
   BOOL _playbackRateObserverRegistered;
@@ -221,33 +218,8 @@ static int const RCTVideoUnset = -1;
   [[NSNotificationCenter defaultCenter] removeObserver:self];
   [self removePlayerLayer];
   [self removePlayerItemObservers];
-  [self removeSpatialAudioRemoteCommandHandler];
   [_player removeObserver:self forKeyPath:playbackRate context:nil];
   [_player removeObserver:self forKeyPath:externalPlaybackActive context: nil];
-}
-
-#pragma mark - Spatial Audio / Dolby Atmos Workaround
-
-/* These functions are a temporarily workaround to enable the rendering of Dolby Atmos on
- * iOS 15 and above.
- */
-- (void)addSpatialAudioRemoteCommandHandler
-{
-  MPRemoteCommand *remoteCommand = [MPRemoteCommandCenter sharedCommandCenter].playCommand;
-  
-  _remoteCommandHandlerForSpatialAudio = [remoteCommand addTargetWithHandler:^MPRemoteCommandHandlerStatus(MPRemoteCommandEvent *event) {
-      return MPRemoteCommandHandlerStatusSuccess;
-  }];
-}
-
-- (void)removeSpatialAudioRemoteCommandHandler
-{
-  MPRemoteCommand *remoteCommand = [MPRemoteCommandCenter sharedCommandCenter].playCommand;
-  
-  if (_remoteCommandHandlerForSpatialAudio != nil) {
-      [remoteCommand removeTarget:_remoteCommandHandlerForSpatialAudio];
-      _remoteCommandHandlerForSpatialAudio = nil;
-  }
 }
 
 #pragma mark - App lifecycle handlers
@@ -389,7 +361,6 @@ static int const RCTVideoUnset = -1;
   [self removePlayerLayer];
   [self removePlayerTimeObserver];
   [self removePlayerItemObservers];
-  [self removeSpatialAudioRemoteCommandHandler];
 
   dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t) 0), dispatch_get_main_queue(), ^{
     
@@ -399,7 +370,6 @@ static int const RCTVideoUnset = -1;
       _playerItem = playerItem;
       [self setPreferredForwardBufferDuration:_preferredForwardBufferDuration];
       [self addPlayerItemObservers];
-      [self addSpatialAudioRemoteCommandHandler];
 
       [self setFilter:self->_filterName];
       [self setMaxBitRate:self->_maxBitRate];


### PR DESCRIPTION
There was an Apple bug on iOS 15 that was not rendering Atmos. We implemented a workaround using MPRemoteCommandCenter to force Atmos to render. Apple has since this bug and our workaround can be removed

To test if Atmos is playing correctly, use the test stream found at : https://ott.dolby.com/OnDelKits/DDP/Dolby_Digital_Plus_Online_Delivery_Kit_v1.5/Test_Signals/muxed_streams/HLS/Manifest_fMP4/Audio_ID_720p_50fps_h264_special_6ch_640kbps_ddp_joc.m3u8

**Note the following are required to test**
- iPhone 7 or higher
- AirPods